### PR TITLE
Fixes plugin name and uses title instead of namespace

### DIFF
--- a/plugin/$slug.php.mustache
+++ b/plugin/$slug.php.mustache
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       {{namespace}}
+ * Plugin Name:       {{title}}
 {{#description}}
  * Description:       {{description}}
 {{/description}}


### PR DESCRIPTION
Fixed #1 